### PR TITLE
Report Alembic arb/userProperties to created QEntities

### DIFF
--- a/src/AlembicEntity.cpp
+++ b/src/AlembicEntity.cpp
@@ -206,12 +206,17 @@ void AlembicEntity::visitAbcObject(Alembic::Abc::IObject iObj, Alembic::Abc::M44
     using namespace Alembic::AbcGeom;
 
     const MetaData& md = iObj.getMetaData();
+
     if(IPoints::matches(md))
     {
         auto cloud = new PointCloudEntity(this);
         cloud->setData(iObj);
         cloud->setTransform(mat);
         cloud->addComponent(_cloudMaterial);
+        IPoints points(iObj, Alembic::Abc::kWrapExisting);
+        cloud->setObjectName(points.getName().c_str());
+        cloud->fillArbProperties(points.getSchema().getArbGeomParams());
+        cloud->fillUserProperties(points.getSchema().getUserProperties());
     }
     else if(IXform::matches(md))
     {
@@ -225,6 +230,10 @@ void AlembicEntity::visitAbcObject(Alembic::Abc::IObject iObj, Alembic::Abc::M44
         auto cameraLocator = new CameraLocatorEntity(this);
         cameraLocator->setTransform(mat);
         cameraLocator->addComponent(_cameraMaterial);
+        ICamera cam(iObj, Alembic::Abc::kWrapExisting);
+        cameraLocator->setObjectName(cam.getName().c_str());
+        cameraLocator->fillArbProperties(cam.getSchema().getArbGeomParams());
+        cameraLocator->fillUserProperties(cam.getSchema().getUserProperties());
     }
 
     // visit children

--- a/src/AlembicEntity.hpp
+++ b/src/AlembicEntity.hpp
@@ -7,9 +7,11 @@
 #include <Qt3DCore/QTransform>
 #include <Qt3DRender/QParameter>
 #include <Qt3DRender/QMaterial>
+#include <QQmlListProperty>
 
 namespace abcentity
 {
+class CameraLocatorEntity;
 
 class AlembicEntity : public Qt3DCore::QEntity
 {
@@ -19,6 +21,7 @@ class AlembicEntity : public Qt3DCore::QEntity
         float particleSize READ particleSize WRITE setParticleSize NOTIFY particleSizeChanged)
     Q_PROPERTY(
         float locatorScale READ locatorScale WRITE setLocatorScale NOTIFY locatorScaleChanged)
+    Q_PROPERTY(QQmlListProperty<abcentity::CameraLocatorEntity> cameras READ cameras NOTIFY camerasChanged)
 
 public:
     AlembicEntity(Qt3DCore::QNode* = nullptr);
@@ -33,15 +36,26 @@ public:
     Q_SLOT void setLocatorScale(const float&);
 
 private:
+    /// Delete all child entities/components
+    void clear();
     void createMaterials();
     void loadAbcArchive();
     void visitAbcObject(Alembic::Abc::IObject, Alembic::Abc::M44d);
 
+    QQmlListProperty<CameraLocatorEntity> cameras() {
+        return QQmlListProperty<CameraLocatorEntity>(this, _cameras);
+    }
+
 public:
     Q_SIGNAL void urlChanged();
+    Q_SIGNAL void camerasChanged();
     Q_SIGNAL void particleSizeChanged();
     Q_SIGNAL void locatorScaleChanged();
     Q_SIGNAL void objectPicked(Qt3DCore::QTransform* transform);
+
+protected:
+    /// Scale child locators
+    void scaleLocators() const;
 
 private:
     QUrl _url;
@@ -50,6 +64,7 @@ private:
     Qt3DRender::QParameter* _particleSizeParameter;
     Qt3DRender::QMaterial* _cloudMaterial;
     Qt3DRender::QMaterial* _cameraMaterial;
+    QList<CameraLocatorEntity*> _cameras;
 };
 
 } // namespace

--- a/src/BaseAlembicObject.cpp
+++ b/src/BaseAlembicObject.cpp
@@ -1,0 +1,148 @@
+#include "BaseAlembicObject.hpp"
+#include <Qt3DCore/QTransform>
+
+namespace abcentity
+{
+
+BaseAlembicObject::BaseAlembicObject(Qt3DCore::QNode* parent)
+    : Qt3DCore::QEntity(parent)
+{
+}
+
+void BaseAlembicObject::fillArbProperties(const Alembic::Abc::v7::ICompoundProperty &iParent)
+{
+    fillPropertyMap(iParent, _arbProperties);
+}
+
+void BaseAlembicObject::fillUserProperties(const Alembic::Abc::v7::ICompoundProperty &iParent)
+{
+    fillPropertyMap(iParent, _userProperties);
+}
+
+void BaseAlembicObject::setTransform(const Alembic::Abc::M44d& mat)
+{
+    Qt3DCore::QTransform* transform = new Qt3DCore::QTransform;
+    QMatrix4x4 qmat(mat[0][0], mat[1][0], mat[2][0], mat[3][0], mat[0][1], mat[1][1], mat[2][1],
+                    mat[3][1], mat[0][2], mat[1][2], mat[2][2], mat[3][2], mat[0][3], mat[1][3],
+                    mat[2][3], mat[3][3]);
+    transform->setMatrix(qmat);
+    addComponent(transform);
+}
+
+
+template<typename PODTYPE>
+void BaseAlembicObject::addScalarProperty(QVariantMap& data, const Alembic::Abc::IScalarProperty& prop)
+{
+    static const Alembic::Abc::ISampleSelector iss((Alembic::Abc::index_t)0);
+
+    // TODO: handle extent and interpretation
+    PODTYPE val;
+    prop.get(&val, iss);
+    data[prop.getName().c_str()] = val;
+}
+
+template<>
+void BaseAlembicObject::addScalarProperty<std::string>(QVariantMap& data, const Alembic::Abc::IScalarProperty& prop)
+{
+    std::string val;
+    static const Alembic::Abc::ISampleSelector iss((Alembic::Abc::index_t)0);
+    prop.get(&val, iss);
+    data[prop.getName().c_str()] = QString::fromStdString(val);
+}
+
+
+template<typename PODTYPE>
+void BaseAlembicObject::addArrayProperty(QVariantMap& data, const Alembic::Abc::IArrayProperty& prop)
+{
+    Alembic::AbcCoreAbstract::ArraySamplePtr val;
+    prop.get(val);
+    const PODTYPE* _data = static_cast<const PODTYPE*>(val->getData());
+    QVariantList l;
+    l.reserve(val->size());
+    for(size_t k=0; k < val->size(); k++)
+    {
+        l.append(_data[k]);
+    }
+    data[prop.getName().c_str()] = l;
+}
+
+template<>
+void BaseAlembicObject::addArrayProperty<std::string>(QVariantMap& data, const Alembic::Abc::IArrayProperty& prop)
+{
+    Alembic::AbcCoreAbstract::ArraySamplePtr val;
+    prop.get(val);
+    const std::string* _data = static_cast<const std::string*>(val->getData());
+    QVariantList l;
+    l.reserve(val->size());
+    for(size_t k=0; k < val->size(); k++)
+    {
+        l.append(QString::fromStdString(_data[k]));
+    }
+    data[prop.getName().c_str()] = l;
+}
+
+template<typename PODTYPE>
+void BaseAlembicObject::addProperty(QVariantMap& data, const Alembic::Abc::ICompoundProperty iParent, const Alembic::Abc::PropertyHeader& propHeader)
+{
+    if(propHeader.isArray())
+    {
+        Alembic::Abc::IArrayProperty prop(iParent, propHeader.getName());
+        if(!prop.isConstant())
+            return;
+        addArrayProperty<PODTYPE>(data, prop);
+    }
+    else if(propHeader.isScalar())
+    {
+        Alembic::Abc::IScalarProperty prop(iParent, propHeader.getName());
+        if(!prop.isConstant())
+            return;
+        addScalarProperty<PODTYPE>(data, prop);
+    }
+}
+
+void BaseAlembicObject::fillPropertyMap(const Alembic::Abc::ICompoundProperty& iParent, QVariantMap& variantMap)
+{
+    if(!iParent.valid())
+        return;
+    std::size_t numProps = iParent.getNumProperties();
+    for (std::size_t i = 0; i < numProps; ++i)
+    {
+        const Alembic::Abc::PropertyHeader & propHeader = iParent.getPropertyHeader(i);
+        Alembic::AbcCoreAbstract::DataType dtype = propHeader.getDataType();
+
+        switch(dtype.getPod())
+        {
+        case Alembic::Abc::kBooleanPOD:
+            addProperty<bool>(variantMap, iParent, propHeader); break;
+        case Alembic::Abc::kUint8POD:
+            addProperty<quint8>(variantMap, iParent, propHeader); break;
+        case Alembic::Abc::kUint16POD:
+            addProperty<quint16>(variantMap, iParent, propHeader); break;
+        case Alembic::Abc::kUint32POD:
+            addProperty<quint32>(variantMap, iParent, propHeader); break;
+        case Alembic::Abc::kUint64POD:
+            addProperty<quint64>(variantMap, iParent, propHeader); break;
+        case Alembic::Abc::kInt8POD:
+            addProperty<qint8>(variantMap, iParent, propHeader); break;
+        case Alembic::Abc::kInt16POD:
+            addProperty<qint16>(variantMap, iParent, propHeader); break;
+        case Alembic::Abc::kInt32POD:
+            addProperty<qint32>(variantMap, iParent, propHeader); break;
+        case Alembic::Abc::kInt64POD:
+            addProperty<qint64>(variantMap, iParent, propHeader); break;
+        case Alembic::Abc::kFloat16POD:
+            addProperty<float>(variantMap, iParent, propHeader); break;
+        case Alembic::Abc::kFloat32POD:
+            addProperty<float>(variantMap, iParent, propHeader); break;
+        case Alembic::Abc::kFloat64POD:
+            addProperty<double>(variantMap, iParent, propHeader); break;
+        case Alembic::Abc::kStringPOD:
+            addProperty<std::string>(variantMap, iParent, propHeader); break;
+        case Alembic::Abc::kUnknownPOD:
+        default:
+            break;
+        }
+    }
+};
+
+}

--- a/src/BaseAlembicObject.hpp
+++ b/src/BaseAlembicObject.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <QEntity>
+#include <Alembic/AbcGeom/All.h>
+
+namespace abcentity
+{
+
+/**
+ * @brief BaseAlembicObject is the base class for QEntities instantiated by AlembicEntity
+ */
+class BaseAlembicObject : public Qt3DCore::QEntity
+{
+    Q_OBJECT
+
+    Q_PROPERTY(QVariantMap arbProperties READ arbProperties CONSTANT)
+    Q_PROPERTY(QVariantMap userProperties READ userProperties CONSTANT)
+
+public:
+
+    BaseAlembicObject(Qt3DCore::QNode* = nullptr);
+    ~BaseAlembicObject() = default;
+
+    void setTransform(const Alembic::Abc::M44d&);
+
+    const QVariantMap& arbProperties() const { return _arbProperties; }
+    const QVariantMap& userProperties() const { return _userProperties; }
+
+    void fillArbProperties(const Alembic::Abc::ICompoundProperty& iParent);
+    void fillUserProperties(const Alembic::Abc::ICompoundProperty& iParent);
+
+protected:
+    /// report alembic properties to the given variantMap
+    void fillPropertyMap(const Alembic::Abc::ICompoundProperty& iParent, QVariantMap& variantMap);
+
+    template<typename PODTYPE>
+    void addScalarProperty(QVariantMap& data, const Alembic::Abc::IScalarProperty& prop);
+
+    template<typename PODTYPE>
+    void addArrayProperty(QVariantMap &data, const Alembic::Abc::IArrayProperty &prop);
+
+    template<typename PODTYPE>
+    void addProperty(QVariantMap& data, const Alembic::Abc::ICompoundProperty iParent, const Alembic::Abc::PropertyHeader& propHeader);
+
+protected:
+    QVariantMap _arbProperties;
+    QVariantMap _userProperties;
+};
+
+}

--- a/src/CameraLocatorEntity.cpp
+++ b/src/CameraLocatorEntity.cpp
@@ -9,7 +9,7 @@ namespace abcentity
 {
 
 CameraLocatorEntity::CameraLocatorEntity(Qt3DCore::QNode* parent)
-    : Qt3DCore::QEntity(parent)
+    : BaseAlembicObject(parent)
 {
     using namespace Qt3DRender;
 
@@ -81,16 +81,6 @@ CameraLocatorEntity::CameraLocatorEntity(Qt3DCore::QNode* parent)
     // add components
     addComponent(customMeshRenderer);
     addComponent(picker);
-}
-
-void CameraLocatorEntity::setTransform(const Alembic::Abc::M44d& mat)
-{
-    Qt3DCore::QTransform* transform = new Qt3DCore::QTransform;
-    QMatrix4x4 qmat(mat[0][0], mat[1][0], mat[2][0], mat[3][0], mat[0][1], mat[1][1], mat[2][1],
-                    mat[3][1], mat[0][2], mat[1][2], mat[2][2], mat[3][2], mat[0][3], mat[1][3],
-                    mat[2][3], mat[3][3]);
-    transform->setMatrix(qmat);
-    addComponent(transform);
 }
 
 } // namespace

--- a/src/CameraLocatorEntity.hpp
+++ b/src/CameraLocatorEntity.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "BaseAlembicObject.hpp"
+
 #include <QEntity>
 #include <Alembic/AbcGeom/All.h>
 #include <Alembic/AbcCoreFactory/All.h>
@@ -7,7 +9,7 @@
 namespace abcentity
 {
 
-class CameraLocatorEntity : public Qt3DCore::QEntity
+class CameraLocatorEntity : public BaseAlembicObject
 {
     Q_OBJECT
 
@@ -15,8 +17,6 @@ public:
     CameraLocatorEntity(Qt3DCore::QNode* = nullptr);
     ~CameraLocatorEntity() = default;
 
-public:
-    void setTransform(const Alembic::Abc::M44d&);
 };
 
 } // namespace

--- a/src/PointCloudEntity.cpp
+++ b/src/PointCloudEntity.cpp
@@ -8,7 +8,7 @@ namespace abcentity
 {
 
 PointCloudEntity::PointCloudEntity(Qt3DCore::QNode* parent)
-    : Qt3DCore::QEntity(parent)
+    : BaseAlembicObject(parent)
 {
 }
 
@@ -63,7 +63,6 @@ void PointCloudEntity::setData(const Alembic::Abc::IObject& iObj)
                 if(interp == "rgb")
                 {
                     Alembic::AbcCoreAbstract::DataType dType = prop.getDataType();
-                    Alembic::Util::uint8_t extent = dType.getExtent();
                     Alembic::AbcCoreAbstract::ArraySamplePtr samp;
                     prop.get(samp);
                     QByteArray colorData((const char*)samp->getData(),
@@ -109,14 +108,5 @@ void PointCloudEntity::setData(const Alembic::Abc::IObject& iObj)
     addComponent(customMeshRenderer);
 }
 
-void PointCloudEntity::setTransform(const Alembic::Abc::M44d& mat)
-{
-    Qt3DCore::QTransform* transform = new Qt3DCore::QTransform;
-    QMatrix4x4 qmat(mat[0][0], mat[1][0], mat[2][0], mat[3][0], mat[0][1], mat[1][1], mat[2][1],
-                    mat[3][1], mat[0][2], mat[1][2], mat[2][2], mat[3][2], mat[0][3], mat[1][3],
-                    mat[2][3], mat[3][3]);
-    transform->setMatrix(qmat);
-    addComponent(transform);
-}
 
 } // namespace

--- a/src/PointCloudEntity.hpp
+++ b/src/PointCloudEntity.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "BaseAlembicObject.hpp"
+
 #include <QEntity>
 #include <Alembic/AbcGeom/All.h>
 #include <Alembic/AbcCoreFactory/All.h>
@@ -7,7 +9,7 @@
 namespace abcentity
 {
 
-class PointCloudEntity : public Qt3DCore::QEntity
+class PointCloudEntity : public BaseAlembicObject
 {
     Q_OBJECT
 
@@ -17,7 +19,7 @@ public:
 
 public:
     void setData(const Alembic::Abc::IObject&);
-    void setTransform(const Alembic::Abc::M44d&);
+
 };
 
 } // namespace

--- a/src/plugin.hpp
+++ b/src/plugin.hpp
@@ -18,6 +18,8 @@ public:
     {
         Q_ASSERT(uri == QLatin1String("AlembicEntity"));
         qmlRegisterType<AlembicEntity>(uri, 1, 0, "AlembicEntity");
+        qmlRegisterUncreatableType<CameraLocatorEntity>(uri, 1, 0, "CameraLocatorEntity",
+                                                        "Can't create CameraLocatorEntity intances from QML.");
     }
 };
 


### PR DESCRIPTION
- [x] created entities now contain and expose arbProperties and userProperties as Qt properties (stored as QVariantMaps). Handle scalar and array properties, but do not take 'extent' into account.
- [x] fix camera locators initial scale
- [x] expose cameras as a QQmlListProperty
