### PR TITLE
Proper hierarchy and transformations

### DIFF
--- a/src/AlembicEntity.hpp
+++ b/src/AlembicEntity.hpp
@@ -40,7 +40,7 @@ private:
     void clear();
     void createMaterials();
     void loadAbcArchive();
-    void visitAbcObject(const Alembic::Abc::IObject&, Alembic::Abc::M44d);
+    void visitAbcObject(const Alembic::Abc::IObject&, QEntity* parent);
 
     QQmlListProperty<CameraLocatorEntity> cameras() {
         return QQmlListProperty<CameraLocatorEntity>(this, _cameras);

--- a/src/BaseAlembicObject.cpp
+++ b/src/BaseAlembicObject.cpp
@@ -1,5 +1,4 @@
 #include "BaseAlembicObject.hpp"
-#include <Qt3DCore/QTransform>
 
 namespace abcentity
 {
@@ -7,6 +6,8 @@ namespace abcentity
 BaseAlembicObject::BaseAlembicObject(Qt3DCore::QNode* parent)
     : Qt3DCore::QEntity(parent)
 {
+    _transform = new Qt3DCore::QTransform;
+    addComponent(_transform);    
 }
 
 void BaseAlembicObject::fillArbProperties(const Alembic::Abc::ICompoundProperty &iParent)
@@ -21,12 +22,10 @@ void BaseAlembicObject::fillUserProperties(const Alembic::Abc::ICompoundProperty
 
 void BaseAlembicObject::setTransform(const Alembic::Abc::M44d& mat)
 {
-    Qt3DCore::QTransform* transform = new Qt3DCore::QTransform;
     QMatrix4x4 qmat(mat[0][0], mat[1][0], mat[2][0], mat[3][0], mat[0][1], mat[1][1], mat[2][1],
                     mat[3][1], mat[0][2], mat[1][2], mat[2][2], mat[3][2], mat[0][3], mat[1][3],
                     mat[2][3], mat[3][3]);
-    transform->setMatrix(qmat);
-    addComponent(transform);
+    _transform->setMatrix(qmat);
 }
 
 

--- a/src/BaseAlembicObject.hpp
+++ b/src/BaseAlembicObject.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QEntity>
+#include <Qt3DCore/QTransform>
 #include <Alembic/AbcGeom/All.h>
 
 namespace abcentity
@@ -45,6 +46,7 @@ protected:
 protected:
     QVariantMap _arbProperties;
     QVariantMap _userProperties;
+    Qt3DCore::QTransform* _transform;
 };
 
 }

--- a/src/CameraLocatorEntity.cpp
+++ b/src/CameraLocatorEntity.cpp
@@ -75,12 +75,8 @@ CameraLocatorEntity::CameraLocatorEntity(Qt3DCore::QNode* parent)
     camera->setPosition(QVector3D(0.0f, 3.5f, 25.0f));
     */
 
-    // object picker
-    auto picker = new QObjectPicker;
-
     // add components
     addComponent(customMeshRenderer);
-    addComponent(picker);
 }
 
 } // namespace


### PR DESCRIPTION
Instead of applying XForm's matrix to child objects, create a BaseAlembicObject for each XForm with a proper QTransform component. 

- [x] retrieve original Alembic hierarchy
- [x] fix incorrect transform for objects with multiple XForms in their hierarchies