### PR TITLE
AppVeyor: Save build artifact, update to VS 2019 and Qt 5.14

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,28 +1,21 @@
-version: '1.0.{build}'
-
-image: Visual Studio 2017 
-
-configuration:
-  - Release
-
-platform:
-  - x64
+image: Visual Studio 2019
+configuration: Release
 
 environment:
-  QT5: C:\Qt\5.12\msvc2017_64 
+  QT5: C:\Qt\5.12\msvc2017_64   # Is still available on the VS 2019 image
   APPVEYOR_SAVE_CACHE_ON_ERROR: true
 
 install:
   - vcpkg list
   - vcpkg install
         alembic
-        --triplet %PLATFORM%-windows
+        --triplet x64-windows
   - vcpkg list
  
 before_build:
     - md build
     - cd build
-    - cmake .. -G "Visual Studio 15 2017 Win64"
+    - cmake .. -A x64
             -DCMAKE_BUILD_TYPE=%CONFIGURATION%
             -DCMAKE_PREFIX_PATH=%QT5% 
             -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ image: Visual Studio 2019
 configuration: Release
 
 environment:
-  QT5: C:\Qt\5.12\msvc2017_64   # Is still available on the VS 2019 image
+  QT5: C:\Qt\5.14\msvc2017_64   # Is still available on the VS 2019 image
   APPVEYOR_SAVE_CACHE_ON_ERROR: true
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,3 +38,5 @@ build:
 cache:
   c:\tools\vcpkg\installed\
  
+artifacts:
+ - path: build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,3 +33,6 @@ cache:
  
 artifacts:
  - path: build
+ - path: build\src\Release\alembicEntityQmlPlugin.dll
+ - path: build\src\Release\alembicEntityQmlPlugin.lib
+


### PR DESCRIPTION
 - Saves the build folder as zip file
 - Updates to the Visual Studio 2019 image
 - Updates to Qt 5.14
 - Simplifies the build configuration.

Supports https://github.com/alicevision/meshroom/pull/875.