### PR TITLE
Update installation procedure with latest Meshroom-compatible Qt version

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -3,13 +3,13 @@ This guide will help you build and install qmlAlembic plugin.
 
 ## Requirements
 qmlAlembic requires:
-* [Qt5](https://www.qt.io/) (>= 5.10, make sure to use the **same version** as the target application)
+* [Qt5](https://www.qt.io/) (== 5.15.2, make sure to use the **same version** as the target application)
 * [Alembic](https://github.com/alembic/alembic) (>= 1.7)
 * [CMake](https://cmake.org/) (>= 3.3)
 * On Windows platform: Microsoft Visual Studio (>= 2015.3)
 
 > **Note for Windows**:
-We recommend using [VCPKG](https://github.com/Microsoft/vcpkg) to get Alembic. Qt version there is too old at the moment though, using official installer is necessary.
+We recommend using [VCPKG](https://github.com/Microsoft/vcpkg) to get Alembic. Qt can either be installed with VCPKG or the official installer.
 
 ## Build instructions
 
@@ -20,9 +20,9 @@ In the following steps, replace <INSTALL_PATH> with the installation path of you
 > We will use "NMake Makefiles" generators here to have one-line build/installation,
 but Visual Studio solutions can be generated if need be.
 
-From a developer command-line, using Qt 5.11 (built with VS2015) and VCPKG for Alembic:
+From a developer command-line, using Qt 5.15.2 (built with VS2019) and VCPKG for Alembic:
 ```
-set QT_DIR=/path/to/qt/5.11.0/msvc2017_64
+set QT_DIR=/path/to/qt/5.15.2/msvc2019_64
 cmake .. -DCMAKE_TOOLCHAIN_FILE=%VCPKG_ROOT%\scripts\buildsystems\vcpkg.cmake -DCMAKE_PREFIX_PATH=%QT_DIR% -DVCPKG_TARGET_TRIPLET=x64-windows -G "NMake Makefiles" -DCMAKE_INSTALL_PREFIX=<INSTALL_PATH> -DCMAKE_BUILD_TYPE=Release
 nmake install
 ```
@@ -30,7 +30,7 @@ nmake install
 #### Linux
 
 ```bash
-export QT_DIR=/path/to/qt/5.11.0/gcc_64
+export QT_DIR=/path/to/qt/5.15.2/gcc_64
 export ALEMBIC_DIR=/path/to/alembic/config
 cmake .. -DAlembic_DIR=$ALEMBIC_DIR -DCMAKE_PREFIX_PATH=$QT_DIR -DCMAKE_INSTALL_PREFIX=<INSTALL_PATH> -DCMAKE_BUILD_TYPE=Release
 make install


### PR DESCRIPTION
This PR is related to https://github.com/alicevision/Meshroom/pull/1882 and should be merged at the same time.

Meshroom now uses Qt 5.15.2, so the installation procedure needs to be updated accordingly.

The QmlAlembic plugin itself does not undergo any modification as a consequence of Meshroom's update, but it will need to be rebuilt with Qt 5.15.2 to work properly.