### PR TITLE
[build] Replace Qt3D deprecated functions and fix warnings

### DIFF
--- a/src/AlembicEntity.cpp
+++ b/src/AlembicEntity.cpp
@@ -19,8 +19,8 @@ namespace abcentity
 
 AlembicEntity::AlembicEntity(Qt3DCore::QNode* parent)
     : Qt3DCore::QEntity(parent)
-    , _ioThread(new IOThread())
     , _pointSizeParameter(new Qt3DRender::QParameter)
+    , _ioThread(new IOThread())
 {
     connect(_ioThread.get(), &IOThread::finished, this, &AlembicEntity::onIOThreadFinished);
     createMaterials();
@@ -182,7 +182,7 @@ void AlembicEntity::visitAbcObject(const Alembic::Abc::IObject& iObj, QEntity* p
     using namespace Alembic::Abc;
     using namespace Alembic::AbcGeom;
 
-    const auto createEntity = [&](const IObject& iObject) -> BaseAlembicObject* {
+    const auto createEntity = [&](const IObject&) -> BaseAlembicObject* {
         const MetaData& md = iObj.getMetaData();
 
         if(IPoints::matches(md))

--- a/src/AlembicEntity.cpp
+++ b/src/AlembicEntity.cpp
@@ -145,7 +145,7 @@ void AlembicEntity::loadAbcArchive()
 }
 
 void AlembicEntity::onIOThreadFinished()
-{   
+{
     const auto& archive = _ioThread->archive();
     if(!archive.valid())
     {
@@ -153,7 +153,7 @@ void AlembicEntity::onIOThreadFinished()
         return;
     }
     // visit the abc tree
-    try 
+    try
     {
         visitAbcObject(archive.getTop(), this);
 
@@ -184,7 +184,7 @@ void AlembicEntity::visitAbcObject(const Alembic::Abc::IObject& iObj, QEntity* p
 
     const auto createEntity = [&](const IObject& iObject) -> BaseAlembicObject* {
         const MetaData& md = iObj.getMetaData();
-        
+
         if(IPoints::matches(md))
         {
             IPoints points(iObj, Alembic::Abc::kWrapExisting);

--- a/src/AlembicEntity.hpp
+++ b/src/AlembicEntity.hpp
@@ -29,7 +29,7 @@ class AlembicEntity : public Qt3DCore::QEntity
 
 public:
     // Identical to SceneLoader.Status
-    enum Status { 
+    enum Status {
             None = 0,
             Loading,
             Ready,
@@ -48,11 +48,11 @@ public:
     Q_SLOT void setLocatorScale(const float& value);
 
     Status status() const { return _status; }
-    void setStatus(Status status) { 
-        if(status == _status) 
-            return; 
-        _status = status; 
-        Q_EMIT statusChanged(_status); 
+    void setStatus(Status status) {
+        if(status == _status)
+            return;
+        _status = status;
+        Q_EMIT statusChanged(_status);
     }
 
 private:

--- a/src/BaseAlembicObject.cpp
+++ b/src/BaseAlembicObject.cpp
@@ -7,7 +7,7 @@ BaseAlembicObject::BaseAlembicObject(Qt3DCore::QNode* parent)
     : Qt3DCore::QEntity(parent)
 {
     _transform = new Qt3DCore::QTransform;
-    addComponent(_transform);    
+    addComponent(_transform);
 }
 
 void BaseAlembicObject::fillArbProperties(const Alembic::Abc::ICompoundProperty &iParent)
@@ -81,7 +81,8 @@ void BaseAlembicObject::addArrayProperty<std::string>(QVariantMap& data, const A
 }
 
 template<typename PODTYPE>
-void BaseAlembicObject::addProperty(QVariantMap& data, const Alembic::Abc::ICompoundProperty& iParent, const Alembic::Abc::PropertyHeader& propHeader)
+void BaseAlembicObject::addProperty(QVariantMap& data, const Alembic::Abc::ICompoundProperty& iParent,
+                                    const Alembic::Abc::PropertyHeader& propHeader)
 {
     if(propHeader.isArray())
     {

--- a/src/BaseAlembicObject.cpp
+++ b/src/BaseAlembicObject.cpp
@@ -57,7 +57,7 @@ void BaseAlembicObject::addArrayProperty(QVariantMap& data, const Alembic::Abc::
     prop.get(val);
     const PODTYPE* _data = static_cast<const PODTYPE*>(val->getData());
     QVariantList l;
-    l.reserve(val->size());
+    l.reserve(static_cast<int>(val->size()));
     for(size_t k=0; k < val->size(); k++)
     {
         l.append(_data[k]);
@@ -72,7 +72,7 @@ void BaseAlembicObject::addArrayProperty<std::string>(QVariantMap& data, const A
     prop.get(val);
     const std::string* _data = static_cast<const std::string*>(val->getData());
     QVariantList l;
-    l.reserve(val->size());
+    l.reserve(static_cast<int>(val->size()));
     for(size_t k=0; k < val->size(); k++)
     {
         l.append(QString::fromStdString(_data[k]));
@@ -143,6 +143,6 @@ void BaseAlembicObject::fillPropertyMap(const Alembic::Abc::ICompoundProperty& i
             break;
         }
     }
-};
+}
 
 }

--- a/src/BaseAlembicObject.hpp
+++ b/src/BaseAlembicObject.hpp
@@ -41,7 +41,8 @@ protected:
     void addArrayProperty(QVariantMap &data, const Alembic::Abc::IArrayProperty& prop);
 
     template<typename PODTYPE>
-    void addProperty(QVariantMap& data, const Alembic::Abc::ICompoundProperty& iParent, const Alembic::Abc::PropertyHeader& propHeader);
+    void addProperty(QVariantMap& data, const Alembic::Abc::ICompoundProperty& iParent,
+                     const Alembic::Abc::PropertyHeader& propHeader);
 
 protected:
     QVariantMap _arbProperties;

--- a/src/CameraLocatorEntity.cpp
+++ b/src/CameraLocatorEntity.cpp
@@ -43,13 +43,13 @@ CameraLocatorEntity::CameraLocatorEntity(Qt3DCore::QNode* parent)
 
 
     QByteArray positionData((const char*)points.data(), points.size() * sizeof(float));
-    auto vertexDataBuffer = new QBuffer(QBuffer::VertexBuffer);
+    auto vertexDataBuffer = new QBuffer;
     vertexDataBuffer->setData(positionData);
     auto positionAttribute = new QAttribute;
     positionAttribute->setAttributeType(QAttribute::VertexAttribute);
     positionAttribute->setBuffer(vertexDataBuffer);
-    positionAttribute->setDataType(QAttribute::Float);
-    positionAttribute->setDataSize(3);
+    positionAttribute->setVertexBaseType(QAttribute::Float);
+    positionAttribute->setVertexSize(3);
     positionAttribute->setByteOffset(0);
     positionAttribute->setByteStride(3 * sizeof(float));
     positionAttribute->setCount(points.size() / 3);
@@ -78,13 +78,13 @@ CameraLocatorEntity::CameraLocatorEntity(Qt3DCore::QNode* parent)
         };
 
     QByteArray colorData((const char*)colors.data(), colors.size() * sizeof(float));
-    auto colorDataBuffer = new QBuffer(QBuffer::VertexBuffer);
+    auto colorDataBuffer = new QBuffer;
     colorDataBuffer->setData(colorData);
     auto colorAttribute = new QAttribute;
     colorAttribute->setAttributeType(QAttribute::VertexAttribute);
     colorAttribute->setBuffer(colorDataBuffer);
-    colorAttribute->setDataType(QAttribute::Float);
-    colorAttribute->setDataSize(3);
+    colorAttribute->setVertexBaseType(QAttribute::Float);
+    colorAttribute->setVertexSize(3);
     colorAttribute->setByteOffset(0);
     colorAttribute->setByteStride(3 * sizeof(float));
     colorAttribute->setCount(colors.size() / 3);

--- a/src/CameraLocatorEntity.cpp
+++ b/src/CameraLocatorEntity.cpp
@@ -42,7 +42,7 @@ CameraLocatorEntity::CameraLocatorEntity(Qt3DCore::QNode* parent)
         };
 
 
-    QByteArray positionData((const char*)points.data(), points.size() * sizeof(float));
+    QByteArray positionData((const char*)points.data(), points.size() * static_cast<int>(sizeof(float)));
     auto vertexDataBuffer = new QBuffer;
     vertexDataBuffer->setData(positionData);
     auto positionAttribute = new QAttribute;
@@ -52,7 +52,7 @@ CameraLocatorEntity::CameraLocatorEntity(Qt3DCore::QNode* parent)
     positionAttribute->setVertexSize(3);
     positionAttribute->setByteOffset(0);
     positionAttribute->setByteStride(3 * sizeof(float));
-    positionAttribute->setCount(points.size() / 3);
+    positionAttribute->setCount(static_cast<uint>(points.size() / 3));
     positionAttribute->setName(QAttribute::defaultPositionAttributeName());
     customGeometry->addAttribute(positionAttribute);
 
@@ -77,7 +77,7 @@ CameraLocatorEntity::CameraLocatorEntity(Qt3DCore::QNode* parent)
         1.f, 1.f, 1.f, 1.f, 1.f, 1.f,
         };
 
-    QByteArray colorData((const char*)colors.data(), colors.size() * sizeof(float));
+    QByteArray colorData((const char*)colors.data(), colors.size() * static_cast<int>(sizeof(float)));
     auto colorDataBuffer = new QBuffer;
     colorDataBuffer->setData(colorData);
     auto colorAttribute = new QAttribute;
@@ -87,7 +87,7 @@ CameraLocatorEntity::CameraLocatorEntity(Qt3DCore::QNode* parent)
     colorAttribute->setVertexSize(3);
     colorAttribute->setByteOffset(0);
     colorAttribute->setByteStride(3 * sizeof(float));
-    colorAttribute->setCount(colors.size() / 3);
+    colorAttribute->setCount(static_cast<uint>(colors.size() / 3));
     colorAttribute->setName(QAttribute::defaultColorAttributeName());
     customGeometry->addAttribute(colorAttribute);
 

--- a/src/CameraLocatorEntity.hpp
+++ b/src/CameraLocatorEntity.hpp
@@ -12,7 +12,6 @@ class CameraLocatorEntity : public BaseAlembicObject
 public:
     explicit CameraLocatorEntity(Qt3DCore::QNode* = nullptr);
     ~CameraLocatorEntity() override = default;
-
 };
 
 } // namespace

--- a/src/IOThread.cpp
+++ b/src/IOThread.cpp
@@ -26,7 +26,7 @@ void IOThread::clear()
 }
 
 const Alembic::Abc::IArchive& IOThread::archive() const
-{    
+{
     // mutex is mutable and can be locked in const methods
     QMutexLocker lock(&_mutex);
     return _archive;

--- a/src/PointCloudEntity.cpp
+++ b/src/PointCloudEntity.cpp
@@ -30,13 +30,13 @@ void PointCloudEntity::setData(const Alembic::Abc::IObject& iObj)
 
     // vertices buffer
     QByteArray positionData((const char*)positions->get(), npoints * 3 * sizeof(float));
-    auto vertexDataBuffer = new QBuffer(QBuffer::VertexBuffer);
+    auto vertexDataBuffer = new QBuffer;
     vertexDataBuffer->setData(positionData);
     auto positionAttribute = new QAttribute;
     positionAttribute->setAttributeType(QAttribute::VertexAttribute);
     positionAttribute->setBuffer(vertexDataBuffer);
-    positionAttribute->setDataType(QAttribute::Float);
-    positionAttribute->setDataSize(3);
+    positionAttribute->setVertexBaseType(QAttribute::Float);
+    positionAttribute->setVertexSize(3);
     positionAttribute->setByteOffset(0);
     positionAttribute->setByteStride(3 * sizeof(float));
     positionAttribute->setCount(npoints);
@@ -45,7 +45,7 @@ void PointCloudEntity::setData(const Alembic::Abc::IObject& iObj)
     customGeometry->setBoundingVolumePositionAttribute(positionAttribute);
 
     // read color data
-    auto colorDataBuffer = new QBuffer(QBuffer::VertexBuffer);
+    auto colorDataBuffer = new QBuffer;
 
     // check if we have a color property
     ICompoundProperty cProp = schema.getArbGeomParams();
@@ -88,8 +88,8 @@ void PointCloudEntity::setData(const Alembic::Abc::IObject& iObj)
     auto colorAttribute = new QAttribute;
     colorAttribute->setAttributeType(QAttribute::VertexAttribute);
     colorAttribute->setBuffer(colorDataBuffer);
-    colorAttribute->setDataType(QAttribute::Float);
-    colorAttribute->setDataSize(3);
+    colorAttribute->setVertexBaseType(QAttribute::Float);
+    colorAttribute->setVertexSize(3);
     colorAttribute->setByteOffset(0);
     colorAttribute->setByteStride(3 * sizeof(float));
     colorAttribute->setCount(npoints);

--- a/src/PointCloudEntity.cpp
+++ b/src/PointCloudEntity.cpp
@@ -26,10 +26,10 @@ void PointCloudEntity::setData(const Alembic::Abc::IObject& iObj)
     IPoints points(iObj, kWrapExisting);
     IPointsSchema schema = points.getSchema();
     P3fArraySamplePtr positions = schema.getValue().getPositions();
-    size_t npoints = positions->size();
+    int npoints = static_cast<int>(positions->size());
 
     // vertices buffer
-    QByteArray positionData((const char*)positions->get(), npoints * 3 * sizeof(float));
+    QByteArray positionData((const char*)positions->get(), npoints * 3 * static_cast<int>(sizeof(float)));
     auto vertexDataBuffer = new QBuffer;
     vertexDataBuffer->setData(positionData);
     auto positionAttribute = new QAttribute;
@@ -39,7 +39,7 @@ void PointCloudEntity::setData(const Alembic::Abc::IObject& iObj)
     positionAttribute->setVertexSize(3);
     positionAttribute->setByteOffset(0);
     positionAttribute->setByteStride(3 * sizeof(float));
-    positionAttribute->setCount(npoints);
+    positionAttribute->setCount(static_cast<uint>(npoints));
     positionAttribute->setName(QAttribute::defaultPositionAttributeName());
     customGeometry->addAttribute(positionAttribute);
     customGeometry->setBoundingVolumePositionAttribute(positionAttribute);
@@ -62,11 +62,11 @@ void PointCloudEntity::setData(const Alembic::Abc::IObject& iObj)
                 std::string interp = prop.getMetaData().get("interpretation");
                 if(interp == "rgb")
                 {
-                    Alembic::AbcCoreAbstract::DataType dType = prop.getDataType();
+                    // Alembic::AbcCoreAbstract::DataType dType = prop.getDataType();
                     Alembic::AbcCoreAbstract::ArraySamplePtr samp;
                     prop.get(samp);
                     QByteArray colorData((const char*)samp->getData(),
-                                         samp->size() * 3 * sizeof(float));
+                                         static_cast<int>(samp->size() * 3 * sizeof(float)));
                     colorDataBuffer->setData(colorData);
                     break; // set colors only once
                 }
@@ -78,9 +78,9 @@ void PointCloudEntity::setData(const Alembic::Abc::IObject& iObj)
     if(colorDataBuffer->data().isEmpty())
     {
         auto colors = new float[positions->size() * 3];
-        for(int i = 0; i < positions->size() * 3; i++)
+        for(size_t i = 0; i < positions->size() * 3; i++)
             colors[i] = 0.8f;
-        QByteArray colorData((const char*)colors, npoints * 3 * sizeof(float));
+        QByteArray colorData((const char*)colors, npoints * 3 * static_cast<int>(sizeof(float)));
         colorDataBuffer->setData(colorData);
     }
 
@@ -92,7 +92,7 @@ void PointCloudEntity::setData(const Alembic::Abc::IObject& iObj)
     colorAttribute->setVertexSize(3);
     colorAttribute->setByteOffset(0);
     colorAttribute->setByteStride(3 * sizeof(float));
-    colorAttribute->setCount(npoints);
+    colorAttribute->setCount(static_cast<uint>(npoints));
     colorAttribute->setName(QAttribute::defaultColorAttributeName());
     customGeometry->addAttribute(colorAttribute);
 

--- a/src/PointCloudEntity.hpp
+++ b/src/PointCloudEntity.hpp
@@ -16,7 +16,6 @@ public:
 
 public:
     void setData(const Alembic::Abc::IObject&);
-
 };
 
 } // namespace

--- a/src/plugin.hpp
+++ b/src/plugin.hpp
@@ -13,7 +13,7 @@ class AlembicEntityQmlPlugin : public QQmlExtensionPlugin
     Q_PLUGIN_METADATA(IID "alembicEntity.qmlPlugin")
 
 public:
-    void initializeEngine(QQmlEngine* engine, const char* uri) override {}
+    void initializeEngine(QQmlEngine*, const char*) override {}
     void registerTypes(const char* uri) override
     {
         Q_ASSERT(uri == QLatin1String("AlembicEntity"));


### PR DESCRIPTION
This PR fixes all the warnings on deprecated functions from Qt3D that were raised during compilation. 

It additionally fixes all the "unused variables" warnings as well as most of the warnings about incorrect implicit casts. Trailing spaces have also been cleaned up.